### PR TITLE
fix memory leaks during cleanup

### DIFF
--- a/anyoption.cpp
+++ b/anyoption.cpp
@@ -258,8 +258,13 @@ AnyOption::cleanup()
 	free (optchartype);
 	free (optcharindex);
 	free (usage);
-	if( values != NULL )
-		free (values);
+        if( values != NULL ) {
+            for( int i = 0 ; i < g_value_counter ; i++) {
+                free (values[i]);
+                values[i] = NULL;
+            }
+            free (values);
+        }
 	if( new_argv != NULL )
 		free (new_argv);
 }


### PR DESCRIPTION
The pointers saved in values array should be freed during cleanup.
